### PR TITLE
Sync changes on #9970 back to msquill

### DIFF
--- a/src/css/mathspace/font.less
+++ b/src/css/mathspace/font.less
@@ -1,10 +1,8 @@
 @font-face {
   font-family: 'Symbola';
-  src: url('/permalink/font/symbola/symbola-webfont.eot');
-  /* local() needed for custom fonts to appear in our PDF exports */
-  src: local("Symbola Regular"),
-  url('/permalink/font/symbola/symbola-webfont.eot?#iefix') format('embedded-opentype'),
-  url('/permalink/font/symbola/symbola-webfont.woff') format('woff'),
-  url('/permalink/font/symbola/symbola-webfont.ttf') format('truetype'),
-  url('/permalink/font/symbola/symbola-webfont.svg#SymbolaRegular') format('svg');
+  src: url('/permalink/fonts/symbola/symbola-webfont.eot');
+  src: url('/permalink/fonts/symbola/symbola-webfont.eot?#iefix') format('embedded-opentype'),
+  url('/permalink/fonts/symbola/symbola-webfont.woff') format('woff'),
+  url('/permalink/fonts/symbola/symbola-webfont.ttf') format('truetype'),
+  url('/permalink/fonts/symbola/symbola-webfont.svg#SymbolaRegular') format('svg');
 }


### PR DESCRIPTION
Tested sync is a no-op as it should be:
https://github.com/mathspace/mathspace/wiki/Mathquill#synchronising-mathspacemsquill-with-mathspacemathspace

Needs further investigation, see Trello #9970 for details:
https://trello.com/c/VHaYKPfk/9970-2-part-1-of-5-split-static-assets-out-of-media-root-media-url-to-new-permalink-url-3
https://trello.com/c/zo5xvD9C/10174-fix-msquill-font-location-changes
