### PR TITLE
Remove white-space wrapping because it breaks box mode hints

### DIFF
--- a/src/css/mathspace/math.less
+++ b/src/css/mathspace/math.less
@@ -4,7 +4,6 @@
 
 
 .mq-root-block, .mq-math-mode .mq-root-block {
-  white-space: normal;     // Text wrapping
   overflow: visible;       // Text wrapping
   // So it will align with the text around it
   // Eg..
@@ -14,12 +13,6 @@
 
 
 .mq-math-mode {
-  .mq-non-leaf {
-    // Prevent a bug that occurs on Windows Chrome at non-100% zoom levels, where the
-    // content inside nodes like fractions, roots, etc. would be wrapped
-    white-space: nowrap;
-  }
-
   .mq-binary-operator {
     white-space: pre-wrap;  // MaThSpaCE haCK: Text wrapping
   }

--- a/src/css/mathspace/math.less
+++ b/src/css/mathspace/math.less
@@ -2,8 +2,12 @@
  * All Mathspace-specific Mathquill styles should live in this file.
  */
 
+.mq-editable-field .mq-cursor {
+  width: 1px;
+}
 
 .mq-root-block, .mq-math-mode .mq-root-block {
+  white-space: normal;     // Text wrapping
   overflow: visible;       // Text wrapping
   // So it will align with the text around it
   // Eg..


### PR DESCRIPTION
[Please note, I haven't built the release package correctly here.  I think I need to increment the release version number and build again before we merge this - I just want the idea itself to be reviewable first.]

We recently fixed a bug that manifest on recent versions of Chrome, whereby whitespace would wrap, breaking the input for certain expressions:

https://github.com/mathspace/msquill/commit/5dc79e352751376b55e179002fdb4b27172cb17e

This bug has re-appeared for so-called box mode hints, where the horizontal space available is more constrained and the line break appears in a different place in the content (repro described below).

<img width="453" alt="image" src="https://user-images.githubusercontent.com/38869925/221734401-68fb9c49-69ab-4c72-b1cd-43ad3ef7de33.png">
 
 [Please ignore the mathematics, which has no relation to the question!]
 
 Our existing fix prevents wrapping within `non-leaf` class elements, but in this instance, the line is instead being broken _between_ `non-leaf` elements.  ie. the elements themselves aren't being wrapped, but the `mq-root-block` 
 
 
<img width="1029" alt="image" src="https://user-images.githubusercontent.com/38869925/221736010-0949bb2c-69e4-4ad9-b25d-3c087ade8ed1.png">

 
 This change removes the `normal` whitespace wrapping altogether, and also the now-redundant specialisation from the previous fix, which restored `no-wrap` for specific nestings of elements.  Of course, this feels risky, because it must have been added for a reason!  
 
 Perhaps there is a further, more specific place that we can overwrite this instead?
 
 ---
 
 ## Repro:
 
 To see the problem locally requires a subproblem with box-mode type hints.  
 
 You can visit http://localhost:8000/debug/#!/problem-preview, enter problem template ID 3930, `Show` and then `Try this problem`.  You can then request two hints - the second hint will trigger "box mode":
 
 
<img width="565" alt="image" src="https://user-images.githubusercontent.com/38869925/221735788-5596a1c7-4bc8-4618-ba53-b380d29b2900.png">

 