### PR TITLE
Sqd 2585 mathquill still going funky with browser zoom in while in box mode lindsay winkler 2

### DIFF
--- a/build/mathquill-mathspace.css
+++ b/build/mathquill-mathspace.css
@@ -322,9 +322,6 @@
 .mq-math-mode {
   /* Undo styles from Bootstrap 3's _normalize.scss */
 }
-.mq-math-mode .mq-non-leaf {
-  white-space: nowrap;
-}
 .mq-math-mode .mq-binary-operator {
   white-space: pre-wrap;
 }

--- a/build/mathquill-mathspace.css
+++ b/build/mathquill-mathspace.css
@@ -434,6 +434,19 @@
 .mq-math-mode .mq-supsub + .mq-supsub.mq-sup-only:before {
   top: 0.5em;
 }
+.mq-editable-field .mq-cursor {
+  width: 1px;
+}
+/* never inject a child into the cursor */
+.mq-editable-field .mq-cursor:only-child:after,
+.mq-editable-field .mq-textarea + .mq-cursor:last-child:after {
+  display: none;
+}
+/* if we have an empty editable which only contains the cursor element, keep the injected node in the field that was there when the cursor element didn't exist, so that the width of the field remains consistent */
+.mq-editable-field .mq-root-block:has(> .mq-cursor:only-child)::after {
+  content: 'c';
+  visibility: hidden;
+}
 .mq-math-mode .mq-selection,
 .mq-editable-field .mq-selection,
 .mq-math-mode .mq-selection .mq-non-leaf,

--- a/build/mathquill-mathspace.css
+++ b/build/mathquill-mathspace.css
@@ -437,15 +437,17 @@
 .mq-editable-field .mq-cursor {
   width: 1px;
 }
-/* never inject a child into the cursor */
-.mq-editable-field .mq-cursor:only-child:after,
-.mq-editable-field .mq-textarea + .mq-cursor:last-child:after {
-  display: none;
-}
-/* if we have an empty editable which only contains the cursor element, keep the injected node in the field that was there when the cursor element didn't exist, so that the width of the field remains consistent */
-.mq-editable-field .mq-root-block:has(> .mq-cursor:only-child)::after {
-  content: 'c';
-  visibility: hidden;
+@supports selector(:has(*)) {
+  /* never inject a child into the cursor */
+  .mq-editable-field .mq-cursor:only-child:after,
+  .mq-editable-field .mq-textarea + .mq-cursor:last-child:after {
+    display: none;
+  }
+  /* if we have an empty editable which only contains the cursor element, keep the injected node in the field that was there when the cursor element didn't exist, so that the width of the field remains consistent */
+  .mq-editable-field .mq-root-block:has(> .mq-cursor:only-child)::after {
+    content: 'c';
+    visibility: hidden;
+  }
 }
 .mq-math-mode .mq-selection,
 .mq-editable-field .mq-selection,

--- a/src/css/mathspace/math.less
+++ b/src/css/mathspace/math.less
@@ -171,3 +171,18 @@
   }
 
 }
+
+.mq-editable-field .mq-cursor {
+  width: 1px;
+}
+
+/* never inject a child into the cursor */
+.mq-editable-field .mq-cursor:only-child:after, .mq-editable-field .mq-textarea + .mq-cursor:last-child:after {
+  display: none;
+}
+
+/* if we have an empty editable which only contains the cursor element, keep the injected node in the field that was there when the cursor element didn't exist, so that the width of the field remains consistent */
+.mq-editable-field .mq-root-block:has(> .mq-cursor:only-child)::after {
+    content: 'c';
+    visibility: hidden;
+}

--- a/src/css/mathspace/math.less
+++ b/src/css/mathspace/math.less
@@ -176,13 +176,15 @@
   width: 1px;
 }
 
-/* never inject a child into the cursor */
-.mq-editable-field .mq-cursor:only-child:after, .mq-editable-field .mq-textarea + .mq-cursor:last-child:after {
-  display: none;
-}
-
-/* if we have an empty editable which only contains the cursor element, keep the injected node in the field that was there when the cursor element didn't exist, so that the width of the field remains consistent */
-.mq-editable-field .mq-root-block:has(> .mq-cursor:only-child)::after {
-    content: 'c';
-    visibility: hidden;
+@supports selector(:has(*)) {
+  /* never inject a child into the cursor */
+  .mq-editable-field .mq-cursor:only-child:after, .mq-editable-field .mq-textarea + .mq-cursor:last-child:after {
+    display: none;
+  }
+  
+  /* if we have an empty editable which only contains the cursor element, keep the injected node in the field that was there when the cursor element didn't exist, so that the width of the field remains consistent */
+  .mq-editable-field .mq-root-block:has(> .mq-cursor:only-child)::after {
+      content: 'c';
+      visibility: hidden;
+  }
 }

--- a/src/css/mathspace/math.less
+++ b/src/css/mathspace/math.less
@@ -14,12 +14,6 @@
 
 
 .mq-math-mode {
-  .mq-non-leaf {
-    // Prevent a bug that occurs on Windows Chrome at non-100% zoom levels, where the
-    // content inside nodes like fractions, roots, etc. would be wrapped
-    white-space: nowrap;
-  }
-
   .mq-binary-operator {
     white-space: pre-wrap;  // MaThSpaCE haCK: Text wrapping
   }


### PR DESCRIPTION
This PR revisits and more neatly solves an issue that we've tried a couple of times to fix: content wrapping in unfortunate ways in Mathquill dynamic inputs, in recent versions of Chrome.

The underlying issue is that we have a cursor which takes up space in the layout, even though only the left border is visible to us.  This causes whitespace wrapping in some cases, even when a user doesn't perceive this consumption of space.

Previously, we've made attempts to adjust whitespace wrapping in certain nestings of CSS classes, but new cases have arisen that make this approach unviable (we sometimes have wrapping in an unnested component).

---

This PR instead changes the width of the cursor to be only one pixel.  It also introduces some CSS to fix a problem of the cursor height growing under this circumstance.

It was identified by Kerrin that in certain cases, Mathquill injects an invisible placeholder element, and it's _that_ element that causes wrapping in this new case.

So the additional CSS rules prevent that happening.  It's noted that the new `:has` selector is utilised, which will not be available in older browsers, but it's rationalised that this fix only applies to newer versions of Chrome, where it _will_ be supported.

---

This PR also reverts the previous changes to wrapping rules, which are no longer necessary.

Further discussion here:

https://mathspace.slack.com/archives/C0JGMF0CE/p1678229341107499