### PR TITLE
Allow multiplication symbol to be configured

### DIFF
--- a/build/mathquill.js
+++ b/build/mathquill.js
@@ -1575,7 +1575,16 @@ Controller.open(function(_) {
       ignoredCharacters: {}
     };
 
-    // Process injected commands into autocommands 
+    // MatHSPaCE HacK - Allow multiplication sign to be configurable
+    var multiplicationDisplaySymbol =
+      (this.cursor.options.multiplicationDisplaySymbol =
+        this.cursor.options.multiplicationDisplaySymbol || 'cross');
+    
+    if (multiplicationDisplaySymbol === "dot") {
+      this.cursor.grammarDicts.latexCmds['*'] = LatexCmds.cdot;
+    }
+
+    // Process injected commands into autocommands
     var options = this.cursor.options;
     var commands = options.commands || [];
     var ignoredCharacters = options.ignoredCharacters || [];
@@ -5148,6 +5157,8 @@ var InnerMathField = P(MathQuill.MathField, function(_) {
     this.__options.preventBackslash = ultimateRoot.cursor.options.preventBackslash;
     this.__options.spaceBehavesLikeTab = ultimateRoot.cursor.options.spaceBehavesLikeTab;
     this.__options.supSubsRequireOperand = ultimateRoot.cursor.options.supSubsRequireOperand;
+    // MatHSPaCE HacK - Config option for multiplication symbol
+    this.__options.multiplicationDisplaySymbol = ultimateRoot.cursor.options.multiplicationDisplaySymbol;
     var ctrlr = Controller(this, root, container);
     ctrlr.initializeLatexGrammar();
     ctrlr.editable = true;
@@ -5243,8 +5254,22 @@ LatexCmds.simeq = bind(VanillaSymbol, '\\simeq ', '&#11003;');
 
 LatexCmds.interleave = bind(VanillaSymbol, '\\interleave', '&#10996;');
 
-// Map * to times instead of dot
+// MatHSPaCE HacK Map * to times instead of dot
 CharCmds['*'] = LatexCmds.times;
+
+// MatHSPaCE HacK - Allow multiplication sign to be configurable
+Options.p.multiplicationDisplaySymbol = {};
+optionProcessors.multiplicationDisplaySymbol = function (option) {
+  if (option && option !== "cross" && option !== "dot") {
+    throw (
+      '"cross" or "dot" required for multiplicationDisplaySymbol option, ' +
+      'got "' +
+      option +
+      '"'
+    );
+  }
+  return option;
+};
 
 // Patched latex for % symbol, it should not contain \\ in the beginning.
 LatexCmds['%'] = bind(NonSymbolaSymbol, '%', '%');

--- a/build/mathquill.js
+++ b/build/mathquill.js
@@ -1576,13 +1576,9 @@ Controller.open(function(_) {
     };
 
     // MatHSPaCE HacK - Allow multiplication sign to be configurable
-    var multiplicationDisplaySymbol =
-      (this.cursor.options.multiplicationDisplaySymbol =
-        this.cursor.options.multiplicationDisplaySymbol || 'cross');
-    
-    if (multiplicationDisplaySymbol === "dot") {
-      this.cursor.grammarDicts.latexCmds['*'] = LatexCmds.cdot;
-    }
+    if (this.cursor.options.multiplicationDisplaySymbol === "dot") {
+      this.cursor.grammarDicts.latexCmds["*"] = LatexCmds.cdot;
+    }  
 
     // Process injected commands into autocommands
     var options = this.cursor.options;
@@ -5258,7 +5254,7 @@ LatexCmds.interleave = bind(VanillaSymbol, '\\interleave', '&#10996;');
 CharCmds['*'] = LatexCmds.times;
 
 // MatHSPaCE HacK - Allow multiplication sign to be configurable
-Options.p.multiplicationDisplaySymbol = {};
+Options.p.multiplicationDisplaySymbol = 'cross';
 optionProcessors.multiplicationDisplaySymbol = function (option) {
   if (option && option !== "cross" && option !== "dot") {
     throw (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msquill",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "main": "build/mathquill.js",
   "private": true,
   "dependencies": {

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -739,6 +739,8 @@ var InnerMathField = P(MathQuill.MathField, function(_) {
     this.__options.preventBackslash = ultimateRoot.cursor.options.preventBackslash;
     this.__options.spaceBehavesLikeTab = ultimateRoot.cursor.options.spaceBehavesLikeTab;
     this.__options.supSubsRequireOperand = ultimateRoot.cursor.options.supSubsRequireOperand;
+    // MatHSPaCE HacK - Config option for multiplication symbol
+    this.__options.multiplicationDisplaySymbol = ultimateRoot.cursor.options.multiplicationDisplaySymbol;
     var ctrlr = Controller(this, root, container);
     ctrlr.initializeLatexGrammar();
     ctrlr.editable = true;

--- a/src/commands/mathspace/mathspaceCommands.js
+++ b/src/commands/mathspace/mathspaceCommands.js
@@ -10,7 +10,7 @@ LatexCmds.interleave = bind(VanillaSymbol, '\\interleave', '&#10996;');
 CharCmds['*'] = LatexCmds.times;
 
 // MatHSPaCE HacK - Allow multiplication sign to be configurable
-Options.p.multiplicationDisplaySymbol = {};
+Options.p.multiplicationDisplaySymbol = 'cross';
 optionProcessors.multiplicationDisplaySymbol = function (option) {
   if (option && option !== "cross" && option !== "dot") {
     throw (

--- a/src/commands/mathspace/mathspaceCommands.js
+++ b/src/commands/mathspace/mathspaceCommands.js
@@ -6,8 +6,22 @@ LatexCmds.simeq = bind(VanillaSymbol, '\\simeq ', '&#11003;');
 
 LatexCmds.interleave = bind(VanillaSymbol, '\\interleave', '&#10996;');
 
-// Map * to times instead of dot
+// MatHSPaCE HacK Map * to times instead of dot
 CharCmds['*'] = LatexCmds.times;
+
+// MatHSPaCE HacK - Allow multiplication sign to be configurable
+Options.p.multiplicationDisplaySymbol = {};
+optionProcessors.multiplicationDisplaySymbol = function (option) {
+  if (option && option !== "cross" && option !== "dot") {
+    throw (
+      '"cross" or "dot" required for multiplicationDisplaySymbol option, ' +
+      'got "' +
+      option +
+      '"'
+    );
+  }
+  return option;
+};
 
 // Patched latex for % symbol, it should not contain \\ in the beginning.
 LatexCmds['%'] = bind(NonSymbolaSymbol, '%', '%');

--- a/src/services/commands.js
+++ b/src/services/commands.js
@@ -9,7 +9,16 @@ Controller.open(function(_) {
       ignoredCharacters: {}
     };
 
-    // Process injected commands into autocommands 
+    // MatHSPaCE HacK - Allow multiplication sign to be configurable
+    var multiplicationDisplaySymbol =
+      (this.cursor.options.multiplicationDisplaySymbol =
+        this.cursor.options.multiplicationDisplaySymbol || 'cross');
+    
+    if (multiplicationDisplaySymbol === "dot") {
+      this.cursor.grammarDicts.latexCmds['*'] = LatexCmds.cdot;
+    }
+
+    // Process injected commands into autocommands
     var options = this.cursor.options;
     var commands = options.commands || [];
     var ignoredCharacters = options.ignoredCharacters || [];

--- a/src/services/commands.js
+++ b/src/services/commands.js
@@ -10,13 +10,9 @@ Controller.open(function(_) {
     };
 
     // MatHSPaCE HacK - Allow multiplication sign to be configurable
-    var multiplicationDisplaySymbol =
-      (this.cursor.options.multiplicationDisplaySymbol =
-        this.cursor.options.multiplicationDisplaySymbol || 'cross');
-    
-    if (multiplicationDisplaySymbol === "dot") {
-      this.cursor.grammarDicts.latexCmds['*'] = LatexCmds.cdot;
-    }
+    if (this.cursor.options.multiplicationDisplaySymbol === "dot") {
+      this.cursor.grammarDicts.latexCmds["*"] = LatexCmds.cdot;
+    }  
 
     // Process injected commands into autocommands
     var options = this.cursor.options;


### PR DESCRIPTION
Based on requirements in https://paper.dropbox.com/doc/Support-for-Dot-Multiplication--CLPKlDlR7H1zwPSy7iK9NZzRAg-MKH44mfzLyCuf657gVihF

We want to allow some PTs to have a ⋅ instead of × as the multiplication symbol

---
We add a new Mathquill config option called `multiplicationDisplaySymbol` which has the following options: 'cross' | 'dot'

By default: 'cross' is the options and `\times` will be used
When 'dot' is set as the option we will use `\cdot`

The configuration option just changes how the `*` is interpreted. 
We will be aiming to be lenient as allowing the Math Engine accept both options